### PR TITLE
Use a bitfield sequence to configure LED behaviour for gamepad status.

### DIFF
--- a/app/virtual_gamepad_hub.coffee
+++ b/app/virtual_gamepad_hub.coffee
@@ -8,6 +8,24 @@ log = require '../lib/log'
 config = require '../config'
 
 num_gamepads = config.ledBitFieldSequence.length
+# ledBitFieldSequence should be an array of 'bit fields'.
+# the bit fields are numbers from 0-15, resulting in the following LED arrangements:
+#  0 - ....
+#  1 - *...
+#  2 - .*..
+#  3 - **..
+#  4 - ..*.
+#  5 - *.*.
+#  6 - .**.
+#  7 - ***.
+#  8 - ...*
+#  9 - *..*
+# 10 - .*.*
+# 11 - **.*
+# 12 - ..**
+# 13 - *.**
+# 14 - .***
+# 15 - ****
 
 class virtual_gamepad_hub
 

--- a/app/virtual_gamepad_hub.coffee
+++ b/app/virtual_gamepad_hub.coffee
@@ -5,12 +5,15 @@ Virtual gamepad hub class
 
 gamepad = require './virtual_gamepad'
 log = require '../lib/log'
+config = require '../config'
+
+num_gamepads = config.ledBitFieldSequence.length
 
 class virtual_gamepad_hub
 
   constructor: () ->
     @gamepads = []
-    for i in [0..3]
+    for i in [0..(num_gamepads-1)]
       @gamepads[i] = undefined
 
   connectGamepad: (callback) ->
@@ -19,7 +22,7 @@ class virtual_gamepad_hub
 
     # Check is a slot is available
     # and retrieve the corresponding gamepad id
-    while !freeSlot and padId < 4
+    while !freeSlot and padId < num_gamepads
       if !@gamepads[padId]
         freeSlot = true
       else

--- a/app/virtual_gamepad_hub.js
+++ b/app/virtual_gamepad_hub.js
@@ -6,17 +6,21 @@ Virtual gamepad hub class
  */
 
 (function() {
-  var gamepad, log, virtual_gamepad_hub;
+  var config, gamepad, log, num_gamepads, virtual_gamepad_hub;
 
   gamepad = require('./virtual_gamepad');
 
   log = require('../lib/log');
 
+  config = require('../config');
+
+  num_gamepads = config.ledBitFieldSequence.length;
+
   virtual_gamepad_hub = (function() {
     function virtual_gamepad_hub() {
-      var i, j;
+      var i, j, ref;
       this.gamepads = [];
-      for (i = j = 0; j <= 3; i = ++j) {
+      for (i = j = 0, ref = num_gamepads - 1; 0 <= ref ? j <= ref : j >= ref; i = 0 <= ref ? ++j : --j) {
         this.gamepads[i] = void 0;
       }
     }
@@ -25,7 +29,7 @@ Virtual gamepad hub class
       var freeSlot, padId;
       padId = 0;
       freeSlot = false;
-      while (!freeSlot && padId < 4) {
+      while (!freeSlot && padId < num_gamepads) {
         if (!this.gamepads[padId]) {
           freeSlot = true;
         } else {

--- a/config.json
+++ b/config.json
@@ -2,5 +2,6 @@
   "port": 80,
   "useGamepadByDefault": false,
   "analog": true,
-  "logLevel": "info"
+  "logLevel": "info",
+  "ledBitFieldSequence": [1,2,4,8,9,10,12,13,14,15]
 }

--- a/public/js/virtual_gamepad_client.js
+++ b/public/js/virtual_gamepad_client.js
@@ -459,7 +459,6 @@ $( window ).load(function() {
     socket.on("gamepadConnected", function(data) {
         slotNumber = data.padId;
         ledBitField = data.ledBitField;
-        console.log("Here I am, and", data)
 
         $(".btn").off("touchstart touchend");
 

--- a/public/js/virtual_gamepad_client.js
+++ b/public/js/virtual_gamepad_client.js
@@ -414,12 +414,16 @@ function removegamepad(gamepad) {
  ************************/
 var indicatorOn;
 var slotNumber;
+var ledBitField;
 var initSlotIndicator = function () {
     indicatorOn = false;
     var slotAnimationLoop = function () {
-        if (slotNumber != undefined) {
+        if (ledBitField != undefined) {
             $(".indicator").removeClass("indicatorSelected");
-            $("#indicator_"+(slotNumber+1)).addClass("indicatorSelected");
+            if (ledBitField & 0b0001) { $("#indicator_1").addClass("indicatorSelected"); }
+            if (ledBitField & 0b0010) { $("#indicator_2").addClass("indicatorSelected"); }
+            if (ledBitField & 0b0100) { $("#indicator_3").addClass("indicatorSelected"); }
+            if (ledBitField & 0b1000) { $("#indicator_4").addClass("indicatorSelected"); }
         } else {
             if(indicatorOn) {
                 $(".indicator").removeClass("indicatorSelected");
@@ -454,6 +458,8 @@ $( window ).load(function() {
 
     socket.on("gamepadConnected", function(data) {
         slotNumber = data.padId;
+        ledBitField = data.ledBitField;
+        console.log("Here I am, and", data)
 
         $(".btn").off("touchstart touchend");
 

--- a/server.coffee
+++ b/server.coffee
@@ -52,10 +52,11 @@ io.on 'connection', (socket) ->
 
   socket.on 'connectGamepad', () ->
     gp_hub.connectGamepad (gamePadId) ->
+      ledBitField = config.ledBitFieldSequence[gamePadId]
       if gamePadId != -1
         log 'info', 'connectGamepad: success'
         socket.gamePadId = gamePadId
-        socket.emit 'gamepadConnected', {padId: gamePadId}
+        socket.emit 'gamepadConnected', {padId: gamePadId, ledBitField: ledBitField}
       else
         log 'warning', 'connectGamepad: failed'
 

--- a/server.js
+++ b/server.js
@@ -69,11 +69,14 @@ Virtual gamepad application
     });
     socket.on('connectGamepad', function() {
       return gp_hub.connectGamepad(function(gamePadId) {
+        var ledBitField;
+        ledBitField = config.ledBitFieldSequence[gamePadId];
         if (gamePadId !== -1) {
           log('info', 'connectGamepad: success');
           socket.gamePadId = gamePadId;
           return socket.emit('gamepadConnected', {
-            padId: gamePadId
+            padId: gamePadId,
+            ledBitField: ledBitField
           });
         } else {
           return log('warning', 'connectGamepad: failed');


### PR DESCRIPTION
- app/virtual_gamepad_hub.coffee now depends on config.json to get the number of valid gamepads.
- an additional bitField parameter is passed over the socket in the gamepadConnected message
- I did not remove the slotNumber variable and associated code from virtual_gamepad_client.js, even though it looks to be unused.
- config.json requires ledBitFieldSequence to configure the LEDs. Each array index looks up the LED configuration for the associated playerID. (both 0 indexed)
- this follows discussion and closes #61 

The bit field is ordered with the LSB on the left - corresponding with LED 1. This allows the bit field and player number to map monotonically, rather than jumping around confusingly.