### PR TITLE
Updated dependencies for Node 12

### DIFF
--- a/lib/uinput_structs.js
+++ b/lib/uinput_structs.js
@@ -1,10 +1,10 @@
 // note: underscores instead of camel casing was used in variable names. This
 // was done to keep the name consistent with the underlying c/c++ files.
 
-var ref = require('ref');
+var ref = require('ref-napi');
 var io = require('./io');
-var ArrayType = require('ref-array');
-var StructType = require('ref-struct');
+var ArrayType = require('ref-array-napi');
+var StructType = require('ref-struct-napi');
 var uinput = require('./uinput');
 
 var uinputStructs = {};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "virtual-gamepads",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1104,7 +1104,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1477,7 +1478,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -1525,6 +1527,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -1563,11 +1566,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -2169,6 +2174,11 @@
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
     },
+    "node-addon-api": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.0.tgz",
+      "integrity": "sha512-ASCL5U13as7HhOExbT6OlWJJUV/lLzL2voOSP1UVehpRD8FbSrSDjfScK/KwAvVTI5AS6r4VwbOMlIqtvRidnA=="
+    },
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -2404,56 +2414,48 @@
         "readable-stream": "^2.0.2"
       }
     },
-    "ref": {
-      "version": "git://github.com/TooTallNate/ref.git#924437f94b0f24323008990319871ffcbfc75cd8",
-      "from": "git://github.com/TooTallNate/ref.git#924437f94b0f24323008990319871ffcbfc75cd",
-      "requires": {
-        "bindings": "1",
-        "debug": "2",
-        "nan": "2"
-      }
-    },
-    "ref-array": {
+    "ref-array-napi": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/ref-array/-/ref-array-1.2.0.tgz",
-      "integrity": "sha1-u6hwFS1O4KvtFCGwYjkvCwGEKQw=",
+      "resolved": "https://registry.npmjs.org/ref-array-napi/-/ref-array-napi-1.2.0.tgz",
+      "integrity": "sha512-EkqS2iyJsrPAGu4Cv5bGAItuDEsE9ZXPoICU0dYB7qqLgksIhmMS4HaBRyJVsrTwb6Da/PNAZgBy6T6gN/HbkQ==",
       "requires": {
         "array-index": "1",
         "debug": "2",
-        "ref": "1"
+        "ref-napi": "^1.4.2"
+      }
+    },
+    "ref-napi": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/ref-napi/-/ref-napi-1.4.3.tgz",
+      "integrity": "sha512-yE98eVwjpeGSbHjahn+hNlheGgKdV3gCW1rSj7HZL4ITzBhRb0HlUapWamRcAjZebPr3yuhvxeKFmso8NbRv5g==",
+      "requires": {
+        "bindings": "^1.3.0",
+        "debug": "^3.1.0",
+        "node-addon-api": "^2.0.0"
       },
       "dependencies": {
-        "ref": {
-          "version": "1.3.5",
-          "resolved": "https://registry.npmjs.org/ref/-/ref-1.3.5.tgz",
-          "integrity": "sha512-2cBCniTtxcGUjDpvFfVpw323a83/0RLSGJJY5l5lcomZWhYpU2cuLdsvYqMixvsdLJ9+sTdzEkju8J8ZHDM2nA==",
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "requires": {
-            "bindings": "1",
-            "debug": "2",
-            "nan": "2"
+            "ms": "^2.1.1"
           }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
-    "ref-struct": {
+    "ref-struct-napi": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ref-struct/-/ref-struct-1.1.0.tgz",
-      "integrity": "sha1-XV7mWtQc78Olxf60BYcmHkee3BM=",
+      "resolved": "https://registry.npmjs.org/ref-struct-napi/-/ref-struct-napi-1.1.0.tgz",
+      "integrity": "sha512-9GwNq6PwVKhe8ZX4E51+3knUMJfyQumT9RCsXHBRDPfSYbOfK34TbQlEyvfuPOsb0xOlqzkR3CkTmD8gIdmtgQ==",
       "requires": {
         "debug": "2",
-        "ref": "1"
-      },
-      "dependencies": {
-        "ref": {
-          "version": "1.3.5",
-          "resolved": "https://registry.npmjs.org/ref/-/ref-1.3.5.tgz",
-          "integrity": "sha512-2cBCniTtxcGUjDpvFfVpw323a83/0RLSGJJY5l5lcomZWhYpU2cuLdsvYqMixvsdLJ9+sTdzEkju8J8ZHDM2nA==",
-          "requires": {
-            "bindings": "1",
-            "debug": "2",
-            "nan": "2"
-          }
-        }
+        "ref-napi": "^1.4.2"
       }
     },
     "regex-not": {

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "express": "^4.17.1",
     "ioctl": "^2.0.1",
     "socket.io": "^2.3.0",
-    "ref": "git://github.com/TooTallNate/ref.git#924437f94b0f24323008990319871ffcbfc75cd",
-    "ref-struct": "^1.1.0",
-    "ref-array": "^1.2.0",
+    "ref-napi": "^1.3.5",
+    "ref-struct-napi": "^1.1.0",
+    "ref-array-napi": "^1.2.0",
     "winston": "^3.2.1",
     "forever-monitor": "^2.0.0"
   },


### PR DESCRIPTION
I was having the same problem installing with Node 12 as mentioned here: https://github.com/jehervy/node-virtual-gamepads/issues/69. I was able to fix the problem by updating the dependencies on `ref`, `ref-array`, and `ref-struct` to `ref-napi`, `ref-array-napi`, and `ref-struct-napi`. Now installs and works on Ubuntu 18,04, Node version 12.13.0.

Would you please consider this pull request?

closes #69 