### PR TITLE
Call script from anywhere using path.resolve()

### DIFF
--- a/main.js
+++ b/main.js
@@ -12,7 +12,8 @@ Virtual gamepad application
 
   log = require('./lib/log');
 
-  server = new forever.Monitor('server.js', {
+  server = new forever.Monitor(
+    require('path').resolve(__dirname, 'server.js'), {
     max: Infinity,
     args: []
   });


### PR DESCRIPTION
Calling the script outside the `/node-virtual-gamepads` folder fails as the file server.js cannot be located. Using path.resolve() allows the script to be called from anywhere, e.g. to start the script on boot