### PR TITLE
Add fullscreen button for the gamepad page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Upcoming
 ========
+  * Add fullscreen button for the gamepad page.
 
 1.5.0
 =====

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -9,6 +9,10 @@ body {
     font-family: Verdana, Geneva, sans-serif;
 }
 
+body::backdrop {
+    background-color: inherit;
+}
+
 td {
     text-align: center;
 }
@@ -435,3 +439,15 @@ input:checked + .slider:before {
 .slider.round:before {
     border-radius: 50%;
 }
+
+.fullscreen-link {
+    background-color: transparent;
+    outline: 0;
+    border: 0;
+    margin: 0;
+    padding: 8px;
+    position: absolute;
+    top: 8px;
+    right: 8px;
+}
+

--- a/public/gamepad.html
+++ b/public/gamepad.html
@@ -1179,6 +1179,11 @@
                 </g>
             </g>
         </svg>
-
+        <button class="fullscreen-link">
+          <svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24">
+            <path d="M0 0h24v24H0z" fill="none"/>
+            <path d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z"/>
+          </svg>
+        </button>
     </body>
 </html>

--- a/public/js/virtual_gamepad_client.js
+++ b/public/js/virtual_gamepad_client.js
@@ -523,4 +523,12 @@ $( window ).load(function() {
     socket.on("disconnect", function() {
         location.reload();
     });
+
+    $(".fullscreen-link").click(function() {
+      if (document.fullscreen) {
+          document.exitFullscreen();
+      } else {
+          document.body.requestFullscreen();
+      }
+    });
 } );


### PR DESCRIPTION
The PR adds a fullscreen button to the Gamepad page:

![image](https://user-images.githubusercontent.com/174561/217366872-29ae30f9-f2d4-42f7-913c-e9edb030632f.png)

I own a Pixel 6 and find it quite disturbing that the gamepad sometimes scrolls (even with the web installed as an app). I always ended up typing in the url bar `javascript: document.body.requestFullscreen();` in order to trigger the fullscreen mode. 

The idea of the PR is to have a button for that functionality. I just added added the button, I'm not really sure if the position of it is the best, please tell me if you have in mind any other better way to handle this.